### PR TITLE
Pin scikit-learn to version which support Py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ setup(
         'pandas>=0.18,<1',
 
         # Dependency for mutual information computation.
-        'scikit-learn>=0.18,<1',
+        # Note: 0.21.0 dropped support for Py2
+        'scikit-learn>=0.18,<0.21',
 
         # Dependency for multi-processing.
         'joblib>=0.12,<1',


### PR DESCRIPTION
Without this, install of tensorflow-data-validation fails on Py2:

```
$ pip install tensorflow-data-validation
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Requirement already satisfied: tensorflow-data-validation in /usr/local/lib/python2.7/site-packages (0.13.1)
Requirement already satisfied: numpy<2,>=1.14.5 in /usr/local/lib/python2.7/site-packages (from tensorflow-data-validation) (1.16.3)
Requirement already satisfied: protobuf<4,>=3.7 in /usr/local/Cellar/protobuf/3.7.1/libexec/lib/python2.7/site-packages (from tensorflow-data-validation) (3.7.1)
Requirement already satisfied: six<2,>=1.10 in /usr/local/Cellar/protobuf/3.7.1/libexec/lib/python2.7/site-packages (from tensorflow-data-validation) (1.12.0)
Requirement already satisfied: joblib<1,>=0.12 in /usr/local/lib/python2.7/site-packages (from tensorflow-data-validation) (0.13.2)
Requirement already satisfied: tensorflow-metadata<0.14,>=0.12.1 in /usr/local/lib/python2.7/site-packages (from tensorflow-data-validation) (0.13.0)
Requirement already satisfied: apache-beam[gcp]<3,>=2.11 in /usr/local/lib/python2.7/site-packages (from tensorflow-data-validation) (2.11.0)
Collecting scikit-learn<1,>=0.18 (from tensorflow-data-validation)
  Downloading https://files.pythonhosted.org/packages/9b/94/a24da18837e32ae2d5275b18308a542ae07891617501336b31c81a383cad/scikit-learn-0.21.0.tar.gz (12.2MB)
    100% |████████████████████████████████| 12.2MB 1.1MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/hf/wnv55n855zb4mcgfy4jsv9cr0000gn/T/pip-install-_FNQkF/scikit-learn/setup.py", line 30, in <module>
        % (platform.python_version(), sys.executable))
    RuntimeError: Scikit-learn requires Python 3.5 or later. The current Python version is 2.7.16 installed in /usr/local/opt/python@2/bin/python2.7.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/hf/wnv55n855zb4mcgfy4jsv9cr0000gn/T/pip-install-_FNQkF/scikit-learn/
```

The scikit release notes announcing dropped support for Py<3.4 here: https://scikit-learn.org/stable/whats_new.html#version-0-21-0