### PR TITLE
Make _WeightedCounter serializable

### DIFF
--- a/tensorflow_data_validation/statistics/generators/top_k_uniques_combiner_stats_generator.py
+++ b/tensorflow_data_validation/statistics/generators/top_k_uniques_combiner_stats_generator.py
@@ -120,7 +120,7 @@ class _WeightedCounter(collections.defaultdict):
     for k, v in six.iteritems(other):
       self[k] += v
   
-  def _reduce_(self):
+  def __reduce__(self):
     return type(self), (), None, None, iter(self.items())
 
 

--- a/tensorflow_data_validation/statistics/generators/top_k_uniques_combiner_stats_generator.py
+++ b/tensorflow_data_validation/statistics/generators/top_k_uniques_combiner_stats_generator.py
@@ -119,6 +119,9 @@ class _WeightedCounter(collections.defaultdict):
   def update(self, other: '_WeightedCounter') -> None:
     for k, v in six.iteritems(other):
       self[k] += v
+  
+  def _reduce_(self):
+    return type(self), (), None, None, iter(self.items())
 
 
 class TopKUniquesCombinerStatsGenerator(


### PR DESCRIPTION
I have been trying to make tfdv work with multiple CPUs or even across multiple nodes to generate partials. These partials are then pickled. But due to missing `__reduce__` in `_WeightedCounter`, the pickled partial statistics list is failing to unpickle.

More details: https://stackoverflow.com/questions/59332202/tensorflow-data-validation-serialization-error

Error:
```
_RemoteTraceback: 
'''
Traceback (most recent call last):
  File "/var/hadoop_vol/adyen_pyspark/venv/lib/python3.5/site-packages/joblib/externals/loky/process_executor.py", line 624, in _queue_management_worker
    result_item = result_reader.recv()
  File "/usr/local/python35/lib/python3.5/multiprocessing/connection.py", line 251, in recv
    return ForkingPickler.loads(buf.getbuffer())
TypeError: __init__() takes 1 positional argument but 2 were given
'''
.
.
.
BrokenProcessPool: A result has failed to un-serialize. Please ensure that the objects returned by the function are always picklable.
```
