### PR TITLE
Fixes facets rendering in Chrome M80

### DIFF
--- a/tensorflow_data_validation/utils/display_util.py
+++ b/tensorflow_data_validation/utils/display_util.py
@@ -238,7 +238,7 @@ def get_statistics_html(
   html_template = """<iframe id='facets-iframe' width="100%" height="500px"></iframe>
         <script>
         facets_iframe = document.getElementById('facets-iframe');
-        facets_html = '<link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/master/facets-dist/facets-jupyter.html"><facets-overview proto-input="protostr"></facets-overview>';
+        facets_html = '<script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script><link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/master/facets-dist/facets-jupyter.html"><facets-overview proto-input="protostr"></facets-overview>';
         facets_iframe.srcdoc = facets_html;
          facets_iframe.id = "";
          setTimeout(() => {


### PR DESCRIPTION
Fixes https://github.com/tensorflow/data-validation/issues/108

I'm not familiar with how to build tfdv from master and use it. I'd like some help on this.

## Verification
I've tested fixing facet by running the following in a notebook:
```
!python3 -m pip install facets_overview pandas
from facets_overview.generic_feature_statistics_generator import GenericFeatureStatisticsGenerator

import pandas as pd
df =  pd.DataFrame({'num' : [1, 2, 3, 4], 'str' : ['a', 'a', 'b', None]})
proto = GenericFeatureStatisticsGenerator().ProtoFromDataFrames([{'name': 'test', 'table': df}])

from IPython.core.display import display, HTML
import base64
protostr = base64.b64encode(proto.SerializeToString()).decode("utf-8")
HTML_TEMPLATE = """
        <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-lite.js"></script>
        <link rel="import" href="https://raw.githubusercontent.com/PAIR-code/facets/1.0.0/facets-dist/facets-jupyter.html">
        <facets-overview id="elem"></facets-overview>
        <script>
          document.querySelector("#elem").protoInput = "{protostr}";
        </script>"""
html = HTML_TEMPLATE.format(protostr=protostr)
display(HTML(html))
```

Without the webcomponents-lite.js polyfill, output is empty and Chrome M80 shows a warning of html import not supported.
With the polyfill, I can see the visualization result.