### PR TITLE
Update pip download instructions

### DIFF
--- a/g3doc/get_started.md
+++ b/g3doc/get_started.md
@@ -71,7 +71,7 @@ follows:
 ```sh
 pip download tensorflow_data_validation \
   --no-deps \
-  --platform manylinux1_x86_64 \
+  --platform manylinux2010_x86_64 \
   --only-binary=:all:
 
 ```


### PR DESCRIPTION
Starting from 0.14.0 tfdv started using `manylinux2010_x86_64` as the platform name instead of the `manylinux1_x86_64`. Updating the pip download instructions to download the latest tfdv version instead of the latest version supporting `manylinux1_x86_64` (0.13.1)