### PR TITLE
Upgrading set_option argument from -1 to None to match pandas 1.x API.

### DIFF
--- a/tensorflow_data_validation/utils/display_util.py
+++ b/tensorflow_data_validation/utils/display_util.py
@@ -177,7 +177,7 @@ def display_schema(schema: schema_pb2.Schema) -> None:
   display(features_df)
   # Do not truncate columns.
   if not domains_df.empty:
-    pd.set_option('max_colwidth', -1)
+    pd.set_option('max_colwidth', None)
     display(domains_df)
 
 
@@ -214,7 +214,7 @@ def get_anomalies_dataframe(anomalies: anomalies_pb2.Anomalies) -> pd.DataFrame:
           'Anomaly long description'
       ]).set_index('Feature name')
   # Do not truncate columns.
-  pd.set_option('max_colwidth', -1)
+  pd.set_option('max_colwidth', None)
   return anomalies_df
 
 


### PR DESCRIPTION
Fixed #172 Pandas API 1.x requires None not -1. 