### PR TITLE
Update the joblib version to fix CVE-2022-21797

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup(
         'apache-beam[gcp]>=2.40,<3',
         # TODO(b/139941423): Consider using multi-processing provided by
         # Beam's DirectRunner.
-        'joblib>=0.12,<0.15',  # Dependency for multi-processing.
+        'joblib>=1.2.0',  # Dependency for multi-processing.
         'numpy>=1.16,<2',
         'pandas>=1.0,<2',
         'protobuf>=3.13,<4',

--- a/setup.py
+++ b/setup.py
@@ -221,3 +221,4 @@ setup(
         'build': _BuildCommand,
         'bazel_build': _BazelBuildCommand,
     })
+


### PR DESCRIPTION
The package joblib from 0 and before 1.2.0 are vulnerable to Arbitrary Code Execution via the pre_dispatch flag in Parallel() class due to the eval() statement.