### PR TITLE
Allow compilation by including arm64 macs in mac select conditions

### DIFF
--- a/tensorflow_data_validation/BUILD
+++ b/tensorflow_data_validation/BUILD
@@ -17,10 +17,19 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "macos_arm64",
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin_arm64",
+    },
+)
+
 selects.config_setting_group(
     name = "macos",
     match_any = [
         ":macos_x86_64",
+        ":macos_arm64"
     ],
 )
 


### PR DESCRIPTION
Include detection for arm64 macs when checking for macos so version-script is excluded when linking

Fixes https://github.com/tensorflow/data-validation/issues/205

Happy to work on this, not too familiar with bazel but clean to get tfx working on apple silicon