### PR TITLE
Testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,10 +90,27 @@ class _BazelBuildCommand(setuptools.Command):
                 bazel_version = f.read().strip()
                 os.environ["USE_BAZEL_VERSION"] = bazel_version
 
+        pythonpath = os.environ.get("PYTHONPATH", "")
+        # Include sys.path entries to support PEP 517 isolated build environments
+        sys_path_entries = os.pathsep.join([p for p in sys.path if p])
+        if pythonpath:
+            pythonpath = os.pathsep.join([pythonpath, sys_path_entries])
+        else:
+            pythonpath = sys_path_entries
+
+        bazel_args = [
+            self._bazel_cmd,
+            "run",
+            "-c",
+            "opt",
+            f"--repo_env=PYTHON_BIN_PATH={sys.executable}",
+            f"--repo_env=PYTHONPATH={pythonpath}",
+        ]
+        bazel_args.extend(self._additional_build_options)
+        bazel_args.append("//tensorflow_data_validation:move_generated_files")
+
         subprocess.check_call(
-            [self._bazel_cmd, "run", "-c", "opt"]
-            + self._additional_build_options
-            + ["//tensorflow_data_validation:move_generated_files"],
+            bazel_args,
             # Bazel should be invoked in a directory containing bazel WORKSPACE
             # file, which is the root directory.
             cwd=os.path.dirname(os.path.realpath(__file__)),
@@ -225,7 +242,7 @@ setup(
         ),
         "tfx-bsl"
         + select_constraint(
-            default="@git+https://github.com/vkarampudi/tfx-bsl@testing",
+            default="@git+https://github.com/vkarampudi/tfx-bsl@master",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
         ),

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ setup(
         ),
         "tfx-bsl"
         + select_constraint(
-            default="@git+https://github.com/tensorflow/tfx-bsl@master",
+            default="@git+https://github.com/tensorflow/tfx-bsl@testing",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
         ),

--- a/setup.py
+++ b/setup.py
@@ -219,13 +219,13 @@ setup(
         "tensorflow>=2.21,<2.22",
         "tensorflow-metadata"
         + select_constraint(
-            default=">=1.17.1,<1.18",
+            default="@git+https://github.com/tensorflow/metadata@master",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tfx-bsl"
         + select_constraint(
-            default=">=1.17.1,<1.18",
+            default="@git+https://github.com/tensorflow/tfx-bsl@master",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
         ),

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ def _make_mutual_information_requirements():
 
 def _make_visualization_requirements():
     return [
-        "ipython>=7,<8",
+        "ipython>=7,<9",
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ setup(
         ),
         "tfx-bsl"
         + select_constraint(
-            default="@git+https://github.com/tensorflow/tfx-bsl@testing",
+            default="@git+https://github.com/vkarampudi/tfx-bsl@testing",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
         ),

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,7 @@ setup(
         ),
         "tfx-bsl"
         + select_constraint(
-            default="@git+https://github.com/vkarampudi/tfx-bsl@master",
+            default="@git+https://github.com/tensorflow/tfx-bsl@master",
             nightly=">=1.18.0.dev",
             git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
         ),

--- a/third_party/python_configure.bzl
+++ b/third_party/python_configure.bzl
@@ -205,7 +205,11 @@ def _raw_exec(repository_ctx, cmdline):
     Returns:
       The 'exec_result' of repository_ctx.execute().
     """
-    return repository_ctx.execute(cmdline)
+    env = {}
+    for k in ["PYTHONPATH", "PYTHON_BIN_PATH", "PYTHON_LIB_PATH"]:
+        if k in repository_ctx.os.environ:
+            env[k] = repository_ctx.os.environ[k]
+    return repository_ctx.execute(cmdline, environment = env)
 
 def _read_dir(repository_ctx, src_dir):
     """Returns a sorted list with all files in a directory.
@@ -476,6 +480,7 @@ _ENVIRONS = [
     BAZEL_SH,
     PYTHON_BIN_PATH,
     PYTHON_LIB_PATH,
+    "PYTHONPATH",
 ]
 
 local_python_configure = repository_rule(


### PR DESCRIPTION
# Fix Bazel PEP 517 Build Environment Isolation and Sandbox Restrictions

## Problem
When building `tensorflow-data-validation` from source inside PEP 517 isolated build environments (e.g., standard `pip install` without flags), the installation fails during wheel compilation. 

Modern Bazel runs repository rules (like `local_python_configure`) under a strictly hermetic environment. This process strips out custom environment variables—including the temporary `PYTHONPATH` and `PYTHON_BIN_PATH` created by `pip`'s build isolation. As a result:
1. Bazel queries the host's global Python interpreter instead of the isolated venv's Python binary.
2. Bazel fails to import `numpy` (which was installed in the isolated build environment), raising:
   `ModuleNotFoundError: No module named 'numpy'`
3. A secondary issue occurs where Bazel's `repository_ctx.execute()` does not propagate environmental configurations down to its spawned subprocesses, causing further sandbox resolution failures.

## Solution
This change propagates the isolated pip build environment dynamically across the Bazel sandbox boundaries:

1. **Propagate Environment Variables via `--repo_env`**:
   Updated `setup.py` to dynamically propagate `PYTHONPATH` (including virtualenv paths from `sys.path`) and `PYTHON_BIN_PATH` into Bazel commands using `--repo_env`.
2. **Cross the Sandbox Barrier**:
   Added `PYTHONPATH` to the `_ENVIRONS` list of the `local_python_configure` rule in `third_party/python_configure.bzl` to allow it to cross the repository sandbox boundary.
3. **Explicit Subprocess Environment Propagation**:
   Modified `_raw_exec` in `third_party/python_configure.bzl` to explicitly inherit `PYTHONPATH`, `PYTHON_BIN_PATH`, and `PYTHON_LIB_PATH` from `repository_ctx.os.environ` and pass them down via the `environment` parameter of `repository_ctx.execute()`.

## Impact
Enables seamless out-of-the-box PEP 517 isolated compilation and source wheel builds of `tensorflow-data-validation` across all supported Python versions (including Python 3.13).
