### PR TITLE
Align master branch for 1.22.0.dev development after 1.21.0 release

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -70,7 +70,8 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m build --wheel --no-isolation
-        python -m pip install "dist/*.whl[all,test]"
+        WHEEL_PATH=$(ls dist/*.whl)
+        python -m pip install "${WHEEL_PATH}[all,test]"
 
     - name: Run tests
       shell: bash -l {0}

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -136,4 +136,8 @@ jobs:
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1.9
         with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: wheels/
+          verify-metadata: true
+          verbose: true

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -74,6 +74,7 @@ jobs:
           python -m pip install auditwheel
           auditwheel repair dist/*.whl -w wheelhouse/
           rm -rf dist/
+          mkdir -p dist/
           mv wheelhouse/* dist/
         fi
         WHEEL_PATH=$(ls dist/*.whl)

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -70,6 +70,12 @@ jobs:
       shell: bash -l {0}
       run: |
         python -m build --wheel --no-isolation
+        if [ "$(uname)" == "Linux" ]; then
+          python -m pip install auditwheel
+          auditwheel repair dist/*.whl -w wheelhouse/
+          rm -rf dist/
+          mv wheelhouse/* dist/
+        fi
         WHEEL_PATH=$(ls dist/*.whl)
         python -m pip install "${WHEEL_PATH}[all,test]"
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -66,25 +66,11 @@ jobs:
         python -m pip install numpy>=1.22.0
         python -m pip install --upgrade pip build wheel "setuptools<69.3"
 
-    - name: Build the package
+    - name: Build and install package
       shell: bash -l {0}
       run: |
         python -m build --wheel --no-isolation
-
-    - name: Install wheel and dependencies
-      shell: bash -l {0}
-      run: |
-        export TFX_DEPENDENCY_SELECTOR=GIT_MASTER
-        export USE_BAZEL_VERSION=7.7.0
-        python -m pip install "apache-beam[gcp]>=2.53,<3" "pandas>=1.0,<3" "numpy>=1.22.0"
-        python -m pip install git+https://github.com/tensorflow/metadata.git@master --no-deps
-        # Bypasses PyPI lack of uncompiled prebuilt wheels over modern setups stably
-        python -m pip install git+https://github.com/tensorflow/tfx-bsl.git@master --no-deps
-        python -m pip install "tensorflow>=2.21,<2.22"
-        python -m pip install "absl-py>=0.9,<2.0.0" "joblib>=1.2.0" "pyarrow>=14" "pyfarmhash>=0.2.2,<0.4" "six>=1.12,<2" "dill" "scipy" "scikit-learn"
-        python -m pip install "protobuf==6.31.1" --force-reinstall
-        python -m pip install dist/*.whl --no-deps
-        python -m pip install pytest
+        python -m pip install "dist/*.whl[all,test]"
 
     - name: Run tests
       shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # TensorFlow Data Validation
 
-[![Python](https://img.shields.io/badge/python%7C3.9%7C3.10%7C3.11-blue)](https://github.com/tensorflow/data-validation)
+[![Python](https://img.shields.io/badge/python%7C3.10%7C3.11%7C3.12%7C3.13-blue)](https://github.com/tensorflow/data-validation)
 [![PyPI](https://badge.fury.io/py/tensorflow-data-validation.svg)](https://badge.fury.io/py/tensorflow-data-validation)
 [![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://www.tensorflow.org/tfx/data_validation/api_docs/python/tfdv)
 
@@ -172,7 +172,8 @@ other *untested* combinations may also work.
 
 tensorflow-data-validation                                                            | apache-beam[gcp] | pyarrow | tensorflow        | tensorflow-metadata | tensorflow-transform | tfx-bsl
 ------------------------------------------------------------------------------------- | ---------------- | ------- | ----------------- | ------------------- | -------------------- | -------
-[GitHub master](https://github.com/tensorflow/data-validation/blob/master/RELEASE.md) | 2.65.0           | 10.0.1  | nightly (2.x)     | 1.17.1              | n/a                  | 1.17.1
+[GitHub master](https://github.com/tensorflow/data-validation/blob/master/RELEASE.md) | 2.65.0           | 14.0.0  | nightly (2.x)     | 1.22.0.dev          | n/a                  | 1.22.0.dev
+[1.21.0](https://github.com/tensorflow/data-validation/blob/v1.21.0/RELEASE.md)       | 2.65.0           | 14.0.0  | 2.21              | 1.21.0              | n/a                  | 1.21.0
 [1.17.0](https://github.com/tensorflow/data-validation/blob/v1.17.0/RELEASE.md)       | 2.65.0           | 10.0.1  | 2.17              | 1.17.1              | n/a                  | 1.17.1
 [1.16.1](https://github.com/tensorflow/data-validation/blob/v1.16.1/RELEASE.md)       | 2.59.0           | 10.0.1  | 2.16              | 1.16.1              | n/a                  | 1.16.1
 [1.16.0](https://github.com/tensorflow/data-validation/blob/v1.16.0/RELEASE.md)       | 2.59.0           | 10.0.1  | 2.16              | 1.16.0              | n/a                  | 1.16.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,22 +4,40 @@
 
 ## Major Features and Improvements
 
-*   Upgraded to support TensorFlow 2.21.0.
-*   Added support for Python 3.12 and 3.13.
-*   Dropped support for Python 3.9.
-
 ## Bug Fixes and Other Changes
-
-*   Aligned Protobuf dependency to `>=6.0.0,<7.0.0`.
-*   Updated PyArrow dependency to `>=14`.
-*   Fixed C++ test build issues by defining missing `ASSERT_OK` and `EXPECT_OK` macros, replacing `LOG(FATAL)` with `abort()`, and fixing invalid Protobuf includes.
-*   Fixed Python test failures by updating `assertRaisesRegex` to expect `RuntimeError` wrapping `ValueError` in Beam pipelines.
 
 ## Known Issues
 
 ## Breaking Changes
 
 ## Deprecation
+
+# Version 1.21.0
+
+## Major Features and Improvements
+
+*   Added support for Python 3.12 and 3.13.
+*   Dropped support for Python 3.9.
+
+## Bug Fixes and Other Changes
+
+*   Depends on Protobuf to `>=6.0.0,<7.0.0`.
+*   Depends on Tensorflow to `>=2.21,<2.22`.
+*   Depends on PyArrow `>=14`.
+*   Fixed C++ test build issues by defining missing `ASSERT_OK` and `EXPECT_OK` macros, replacing `LOG(FATAL)` with `abort()`, and fixing invalid Protobuf includes.
+*   Fixed Python test failures by updating `assertRaisesRegex` to expect `RuntimeError` wrapping `ValueError` in Beam pipelines.
+
+## Known Issues
+
+*   N/A
+
+## Breaking Changes
+
+*   N/A
+
+## Deprecation
+
+*   N/A
 
 # Version 1.17.0
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -171,7 +171,8 @@ other *untested* combinations may also work.
 
 tensorflow-data-validation                                                            | apache-beam[gcp] | pyarrow | tensorflow        | tensorflow-metadata | tensorflow-transform | tfx-bsl
 ------------------------------------------------------------------------------------- | ---------------- | ------- | ----------------- | ------------------- | -------------------- | -------
-[GitHub master](https://github.com/tensorflow/data-validation/blob/master/RELEASE.md) | 2.65.0           | 10.0.1  | nightly (1.x/2.x) | 1.17.1              | n/a                  | 1.17.1
+[GitHub master](https://github.com/tensorflow/data-validation/blob/master/RELEASE.md) | 2.65.0           | 14.0.0  | nightly (1.x/2.x) | 1.22.0.dev          | n/a                  | 1.22.0.dev
+[1.21.0](https://github.com/tensorflow/data-validation/blob/v1.21.0/RELEASE.md)       | 2.65.0           | 14.0.0  | 2.21              | 1.21.0              | n/a                  | 1.21.0
 [1.17.0](https://github.com/tensorflow/data-validation/blob/v1.17.0/RELEASE.md)       | 2.65.0           | 10.0.1  | 2.17              | 1.17.1              | n/a                  | 1.17.1
 [1.16.1](https://github.com/tensorflow/data-validation/blob/v1.16.1/RELEASE.md)       | 2.59.0           | 10.0.1  | 2.16              | 1.16.1              | n/a                  | 1.16.1
 [1.16.0](https://github.com/tensorflow/data-validation/blob/v1.16.0/RELEASE.md)       | 2.59.0           | 10.0.1  | 2.16              | 1.16.0              | n/a                  | 1.16.0

--- a/setup.py
+++ b/setup.py
@@ -236,14 +236,14 @@ setup(
         "tensorflow>=2.21,<2.22",
         "tensorflow-metadata"
         + select_constraint(
-            default="@git+https://github.com/tensorflow/metadata@master",
-            nightly=">=1.18.0.dev",
+            default=">=1.21.0,<1.22",
+            nightly=">=1.22.0.dev",
             git_master="@git+https://github.com/tensorflow/metadata@master",
         ),
         "tfx-bsl"
         + select_constraint(
-            default="@git+https://github.com/tensorflow/tfx-bsl@master",
-            nightly=">=1.18.0.dev",
+            default=">=1.21.0,<1.22",
+            nightly=">=1.22.0.dev",
             git_master="@git+https://github.com/tensorflow/tfx-bsl@master",
         ),
     ],

--- a/tensorflow_data_validation/version.py
+++ b/tensorflow_data_validation/version.py
@@ -15,4 +15,4 @@
 """Contains the version string of TFDV."""
 
 # Note that setup.py uses this version.
-__version__ = "1.18.0.dev"
+__version__ = "1.22.0.dev"

--- a/tensorflow_data_validation/workspace.bzl
+++ b/tensorflow_data_validation/workspace.bzl
@@ -8,12 +8,12 @@ def tf_data_validation_workspace():
 
     git_repository(
         name = "com_github_tensorflow_metadata",
-        branch = "master",
+        commit = "da17f4557749ae122284c5be3e43a2f211d3e6e2",
         remote = "https://github.com/tensorflow/metadata.git",
     )
 
     git_repository(
         name = "com_github_tfx_bsl",
-        branch = "master",
+        commit = "79a4c97cec4ecbad3e95838e990f9b3a0c6439c0",
         remote = "https://github.com/tensorflow/tfx-bsl.git",
     )


### PR DESCRIPTION
## Overview
Performs post-release alignment on the `master` branch to prepare the codebase for `1.22.0.dev` active development following the `1.21.0` release.

## Key Changes
* **Development Versioning**: Bumped `__version__ = "1.22.0.dev"` in `tensorflow_data_validation/version.py`.
* **Release Notes**: Added `# Version 1.21.0` release notes section while maintaining an empty `# Current Version (Still in Development)` section at the top of `RELEASE.md`.
* **Python Dependencies Update**: Updated `nightly` fallback version constraints for `tensorflow-metadata` and `tfx-bsl` to `">=1.22.0.dev"`, while maintaining `default` stability fallbacks (`>=1.21.0,<1.22`) and keeping `git_master` constraints pointing to `@master` in `setup.py`.
* **Bazel Workspace Synchronization**: Pinned `com_github_tensorflow_metadata` (`da17f45`) and `com_github_tfx_bsl` (`79a4c97`) to exact remote stable release SHAs in `workspace.bzl`.
* **Documentation Update**: Added the permanent `1.21.0` compatibility row and updated the `GitHub master` row for `1.22.0.dev` in both `README.md` and `docs/install.md`. Updated the Python shield badge to `3.10 | 3.11 | 3.12 | 3.13`.
* **CI Streamlining**: Streamlined the wheel build and installation steps (`dist/*.whl[all,test]`) and integrated PyPI authentication options in `.github/workflows/conda-build.yml`.
